### PR TITLE
Retry count

### DIFF
--- a/SmokeWebTest/task.json
+++ b/SmokeWebTest/task.json
@@ -16,7 +16,7 @@
     "version": {
         "Major": 1,
         "Minor": 4,
-        "Patch": 3
+        "Patch": 4
     },
     "instanceNameFormat": "Smoke Web Test",
     "groups": [
@@ -52,6 +52,16 @@
             "pattern": "^([1-9]|[1-9][0-9]|[1-6][0-9][0-9])$",
             "required": true,
             "helpMarkDown": "Time in seconds before request times out. Accepted values: 1-600",
+            "groupName": "advanced"
+        },
+        {
+            "name": "retryAttemptCount",
+            "type": "string",
+            "label": "Number of Retry Attempts",
+            "defaultValue": 3,
+            "pattern": "([1-4][0-9]|[1-9]|50)$",
+            "required": true,
+            "helpMarkDown": "Nubmer of time to retry the call to the site before failing.  Accepted values: 1-50",
             "groupName": "advanced"
         }
     ],


### PR DESCRIPTION
Added logic for retries.. Sometimes the "spin-up" time of a website or other factors may result in a failure in a website's first test. This retry functionality will allow for the release task to retry the attempted call a few times before it flat-out fails your release.